### PR TITLE
Feature/configurable tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ environment.admin().addTask(new RemoveJobTask());
 environment.admin().addTask(new AddJobTask());
 ```
 
+To enable only some of the tasks, list the tasks you want enabled in the
+`tasks` configuration setting. If left unset, all tasks are enabled.
+
 ## In a Nutshell
 
 Sundial makes adding scheduled jobs to your Java application a walk in the park. Simply define jobs, define triggers, and start the Sundial scheduler. **dropwizard-sundial** makes integrating and configuring the job scheduler into dropwizard a snap.
@@ -63,7 +66,7 @@ public SundialConfiguration getSundialConfiguration() {
 }
 ```
 
-## Edit you app's Dropwizard YAML config file (default values are shown below except for `annotated-jobs-package-name`):
+## Edit you app's Dropwizard YAML config file (default values are shown below except for `annotated-jobs-package-name` and `tasks`):
 ```yml
 sundial:
   thread-pool-size: 10
@@ -73,6 +76,7 @@ sundial:
   start-scheduler-on-load: true
   global-lock-on-load: false
   annotated-jobs-package-name: com.foo.bar.jobs
+  tasks: [startjob, stopjob]
 ```
 
 ## Configure package name for `Job` classes containing `CronTrigger` and `SimpleTrigger` annotations:

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,20 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.dropwizard</groupId>
+			<artifactId>dropwizard-testing</artifactId>
+			<version>${dropwizard.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.dropwizard</groupId>
+			<artifactId>dropwizard-client</artifactId>
+			<version>${dropwizard.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.knowm</groupId>
 			<artifactId>sundial</artifactId>
 			<version>2.1.1</version>
@@ -177,6 +191,22 @@
 					<includes>
 						<include>**/*.java</include>
 					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.19.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/org/knowm/dropwizard/sundial/SundialConfiguration.java
+++ b/src/main/java/org/knowm/dropwizard/sundial/SundialConfiguration.java
@@ -16,6 +16,8 @@
  */
 package org.knowm.dropwizard.sundial;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -44,6 +46,9 @@ public class SundialConfiguration {
 
   @JsonProperty("annotated-jobs-package-name")
   private String annotatedJobsPackageName;
+
+  @JsonProperty("tasks")
+  private Set<String> tasks;
 
   public String getThreadPoolSize() {
 
@@ -113,4 +118,7 @@ public class SundialConfiguration {
     this.annotatedJobsPackageName = annotatedJobsPackageName;
   }
 
+  public Set<String> getTasks() {
+    return tasks;
+  }
 }

--- a/src/test/java/org/knowm/dropwizard/sundial/SundialBundleIT.java
+++ b/src/test/java/org/knowm/dropwizard/sundial/SundialBundleIT.java
@@ -1,0 +1,64 @@
+package org.knowm.dropwizard.sundial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.client.Client;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+
+public class SundialBundleIT extends SundialBundleITBase {
+    @ClassRule
+    public static DropwizardAppRule<TestConfiguration> app = buildApp("test.yml", new Before() {
+        public void before(Environment environment) {
+            client = new JerseyClientBuilder(environment).build("test");
+        }
+    });
+
+    static Client client;
+
+    @Test
+    public void shouldRegisterTasks() throws InterruptedException {
+        final int start;
+
+        synchronized (TestJob.lock) {
+            start = TestJob.runs;
+            startJob(app, client, TestApp.JOB_NAME);
+            while (TestJob.runs == start) {
+                TestJob.lock.wait(1000);
+                assert TestJob.runs != start : "Timed out";
+            }
+        }
+
+        assertThat(TestJob.runs).isEqualTo(start + 1);
+
+        assertThat(stopJob(app, client, TestApp.JOB_NAME)).isTrue();
+    }
+
+    @Test
+    public void shouldIncrementCounters() throws InterruptedException {
+        final int start;
+
+        synchronized (TestJob.lock) {
+            start = TestJob.runs;
+
+            assertThat(readTimerCount(app, client, "org.knowm.dropwizard.sundial.MetricsReporter.job.TestJob"))
+                .isEqualTo(start);
+
+            startJob(app, client, TestApp.JOB_NAME);
+            while (TestJob.runs == start) {
+                TestJob.lock.wait(1000);
+                assert TestJob.runs != start : "Timed out";
+            }
+        }
+
+        assertThat(readTimerCount(app, client, "org.knowm.dropwizard.sundial.MetricsReporter.job.TestJob"))
+            .isEqualTo(start + 1);
+        assertThat(readTimerCount(app, client, "org.knowm.dropwizard.sundial.MetricsReporter.job.TestJob"))
+            .isEqualTo(TestJob.runs);
+    }
+}

--- a/src/test/java/org/knowm/dropwizard/sundial/SundialBundleITBase.java
+++ b/src/test/java/org/knowm/dropwizard/sundial/SundialBundleITBase.java
@@ -1,0 +1,133 @@
+package org.knowm.dropwizard.sundial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.jetty.server.Server;
+import org.knowm.sundial.Job;
+import org.knowm.sundial.SundialJobScheduler;
+import org.knowm.sundial.exceptions.JobInterruptException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.lifecycle.ServerLifecycleListener;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+
+public class SundialBundleITBase {
+    public interface Before {
+        void before(Environment environment);
+    }
+
+    public static DropwizardAppRule<TestConfiguration> buildApp(
+        String configFile, final Before before
+    ) {
+        return new DropwizardAppRule<>(
+            new DropwizardTestSupport<TestConfiguration>(
+                TestApp.class, ResourceHelpers.resourceFilePath(configFile)
+            ) {
+                @Override
+                public void before() {
+                    super.before();
+                    before.before(getEnvironment());
+                }
+            }
+        );
+    }
+
+    public static class TestApp extends Application<TestConfiguration> {
+        public static String JOB_NAME = "TestJob";
+
+        @Override
+        public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+            super.initialize(bootstrap);
+            bootstrap.addBundle(new SundialBundle<TestConfiguration>() {
+                @Override
+                public SundialConfiguration getSundialConfiguration(TestConfiguration configuration) {
+                    return configuration.sundial;
+                }
+            });
+        }
+
+        @Override
+        public void run(TestConfiguration testConfiguration, Environment environment) throws Exception {
+            environment.lifecycle().addServerLifecycleListener(new ServerLifecycleListener() {
+                @Override
+                public void serverStarted(Server server) {
+                    SundialJobScheduler.addJob(JOB_NAME, TestJob.class);
+                }
+            });
+        }
+    }
+
+    public static class TestConfiguration extends Configuration {
+        public SundialConfiguration sundial;
+    }
+
+    public static class TestJob extends Job {
+        static int runs = 0;
+        public static final Object lock = new Object();
+
+        @Override
+        public void doRun() throws JobInterruptException {
+            synchronized (lock) {
+                runs++;
+                lock.notifyAll();
+            }
+        }
+
+    }
+
+    public static void startJob(DropwizardAppRule<TestConfiguration> app, Client client, String jobName) {
+        Response response = client.target(
+            String.format(
+                "http://localhost:%d/%s/tasks/startjob?JOB_NAME=%s",
+                app.getAdminPort(), app.getEnvironment().getAdminContext().getContextPath(), jobName
+            ))
+            .request()
+            .post(Entity.text(""));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    public static boolean stopJob(DropwizardAppRule<TestConfiguration> app, Client client, String jobName) {
+        Response response = client.target(
+            String.format(
+                "http://localhost:%d/%s/tasks/stopjob?JOB_NAME=%s",
+                app.getAdminPort(), app.getEnvironment().getAdminContext().getContextPath(), jobName
+            ))
+            .request()
+            .post(Entity.text(""));
+
+        return response.getStatus() == 200;
+    }
+
+    public static int readTimerCount(DropwizardAppRule<TestConfiguration> app, Client client, String timerName) {
+        Response response = client.target(
+            String.format(
+                "http://localhost:%d/%s/metrics",
+                app.getAdminPort(), app.getEnvironment().getAdminContext().getContextPath()
+            ))
+            .request()
+            .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        JsonNode body = response.readEntity(JsonNode.class);
+
+        if (!body.get("timers").has(timerName)) {
+            return 0;
+        }
+        return body.get("timers").get(timerName).get("count").intValue();
+    }
+}

--- a/src/test/java/org/knowm/dropwizard/sundial/SundialBundleWithoutStopTaskIT.java
+++ b/src/test/java/org/knowm/dropwizard/sundial/SundialBundleWithoutStopTaskIT.java
@@ -1,0 +1,41 @@
+package org.knowm.dropwizard.sundial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.client.Client;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+
+public class SundialBundleWithoutStopTaskIT extends SundialBundleITBase {
+    @ClassRule
+    public static DropwizardAppRule<TestConfiguration> app = buildApp("test-without-stop-task.yml", new Before() {
+        public void before(Environment environment) {
+            client = new JerseyClientBuilder(environment).build("test");
+        }
+    });
+
+    static Client client;
+
+    @Test
+    public void shouldRegisterTasks() throws InterruptedException {
+        final int start;
+
+        synchronized (TestJob.lock) {
+            start = TestJob.runs;
+            startJob(app, client, TestApp.JOB_NAME);
+            while (TestJob.runs == start) {
+                TestJob.lock.wait(1000);
+                assert TestJob.runs != start : "Timed out";
+            }
+        }
+
+        assertThat(TestJob.runs).isEqualTo(start + 1);
+
+        assertThat(stopJob(app, client, TestApp.JOB_NAME)).isFalse();
+    }
+}

--- a/src/test/resources/test-without-stop-task.yml
+++ b/src/test/resources/test-without-stop-task.yml
@@ -1,0 +1,10 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+sundial:
+  thread-pool-size: 1
+  tasks: [startjob]

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -1,0 +1,9 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+sundial:
+  thread-pool-size: 1


### PR DESCRIPTION
Having the `stopjob`, `removejob`  etc. tasks enabled is a security issue for us. Securing the endpoints is a bit complicated, and since we don't use those tasks anyway, it's simpler to make it possible to disable them.

Also added some test cases to show that the configuration is used.
